### PR TITLE
Allow adding multiple conductors

### DIFF
--- a/HuntTrainAssistant/ChatMessageHandler.cs
+++ b/HuntTrainAssistant/ChatMessageHandler.cs
@@ -11,10 +11,11 @@ internal unsafe static class ChatMessageHandler
     internal static (string Aetheryte, uint Territory) LastMessageLoc = (null, 0);
     internal static void Chat_ChatMessage(XivChatType type, uint senderId, ref SeString sender, ref SeString message, ref bool isHandled)
     {
+        var conductorNames = P.config.Conductors.Select(x => x.Name).ToList();
         if (Svc.ClientState.LocalPlayer != null && P.config.Enabled && ((type.EqualsAny(XivChatType.Shout, XivChatType.Yell, XivChatType.Say, XivChatType.CustomEmote, XivChatType.StandardEmote) && Svc.ClientState.TerritoryType.EqualsAny(ValidZones)) || P.config.Debug))
         {
             var isMapLink = false;
-            var isConductorMessage = (P.config.Debug && (sender.ToString().Contains(Svc.ClientState.LocalPlayer.Name.ToString()) || type == XivChatType.Echo)) || (TryDecodeSender(sender, out var s) && s.Name == P.config.CurrentConductor.Name);
+            var isConductorMessage = (P.config.Debug && (sender.ToString().Contains(Svc.ClientState.LocalPlayer.Name.ToString()) || type == XivChatType.Echo)) || (TryDecodeSender(sender, out var s) && conductorNames.Contains(s.Name));
             //InternalLog.Debug($"Message: {message.ToString()} from {sender}, isConductor = {isConductorMessage}");
             foreach (var x in message.Payloads)
             {
@@ -61,7 +62,7 @@ internal unsafe static class ChatMessageHandler
                     break;
                 }
             }
-            if (P.config.SuppressChatOtherPlayers && !isMapLink && !isConductorMessage && P.config.CurrentConductor.Name != string.Empty)
+            if (P.config.SuppressChatOtherPlayers && !isMapLink && !isConductorMessage && conductorNames.Count > 0)
             {
                 isHandled = true;
             }

--- a/HuntTrainAssistant/Config.cs
+++ b/HuntTrainAssistant/Config.cs
@@ -11,7 +11,6 @@ internal class Config : IPluginConfiguration
     public float AutoTeleportAetheryteDistanceDiff = 3f;
     public bool SuppressChatOtherPlayers = true;
     public List<Sender> Conductors = new();
-    public Sender CurrentConductor = new("", 0);
     public bool Debug = false;
     public bool AutoOpenMap = true;
 }

--- a/HuntTrainAssistant/ContextMenuManager.cs
+++ b/HuntTrainAssistant/ContextMenuManager.cs
@@ -31,7 +31,7 @@ internal class ContextMenuManager
     {
         contextMenu = new();
         openMessenger = new GameObjectContextMenuItem(
-            new SeStringBuilder().AddUiForeground("Set as conductor", 578).Build(), AssignConductor);
+            new SeStringBuilder().AddUiForeground("Add as conductor", 578).Build(), AssignConductor);
         contextMenu.OnOpenGameObjectContextMenu += OpenContextMenu;
     }
 
@@ -56,7 +56,7 @@ internal class ContextMenuManager
         var player = args.Text.ToString();
         var world = args.ObjectWorld;
         var s = new Sender(player, world);
-        P.config.CurrentConductor = s;
+        P.config.Conductors.Add(s);
         EzConfigGui.Open();
     }
 }

--- a/HuntTrainAssistant/Gui.cs
+++ b/HuntTrainAssistant/Gui.cs
@@ -19,17 +19,35 @@ internal unsafe static class Gui
     static void Control()
     {
         ImGui.SetNextItemWidth(150f);
-        var cond = P.config.CurrentConductor.Name;
-        ImGuiEx.Text("Current conductor:");
+        var condIndex = 0;
+        var condNames = P.config.Conductors.Select(x => x.Name).ToArray();
+        ImGuiEx.Text("Current conductors:");
         ImGui.SameLine();
         if (ImGui.SmallButton("Clear"))
         {
-            P.config.CurrentConductor = new("", 0);
+            P.config.Conductors.Clear();
         }
         ImGuiEx.SetNextItemFullWidth();
-        if (ImGui.InputText("##curcond", ref cond, 50))
+        ImGui.ListBox("##conds", ref condIndex, condNames, condNames.Length, 3);
+        ImGuiEx.Text("Add conductor:");
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(150f);
+        var newCond = "";
+        if (ImGui.InputText("##newCond", ref newCond, 50, ImGuiInputTextFlags.EnterReturnsTrue))
         {
-            P.config.CurrentConductor = new(cond, 0);
+            if (newCond.Length > 0)
+            {
+                P.config.Conductors.Add(new(newCond, 0));
+                newCond = "";
+            }
+        }
+        // Remove selected conductor
+        if (ImGui.Button("Remove selected conductor"))
+        {
+            if (condIndex >= 0 && condIndex < P.config.Conductors.Count)
+            {
+                P.config.Conductors.RemoveAt(condIndex);
+            }
         }
         if (P.TeleportTo.Territory == 0)
         {
@@ -76,6 +94,6 @@ internal unsafe static class Gui
     static void Help()
     {
         ImGuiEx.TextWrapped("- Be in one of Endwalker hunt zones;");
-        ImGuiEx.TextWrapped("- Assign conductor either by right-clicking them in chat/world or enter their name manually;");
+        ImGuiEx.TextWrapped("- Assign conductors either by right-clicking them in chat/world or enter their names manually;");
     }
 }

--- a/HuntTrainAssistant/HuntTrainAssistant.cs
+++ b/HuntTrainAssistant/HuntTrainAssistant.cs
@@ -36,7 +36,7 @@ public unsafe class HuntTrainAssistant : IDalamudPlugin
         TeleportTo = (null, 0);
         if (!e.EqualsAny(ValidZones))
         {
-            P.config.CurrentConductor = new("", 0);
+            P.config.Conductors.Clear();
         }
     }
 


### PR DESCRIPTION
Not sure if you'll find this useful, but there's a conductor couple on my data center who take turns announcing each mark on a train, meaning the plugin would only work half the time. Here's a quick and dirty change that allows you to add multiple players as conductors, either by entering their names and pressing Enter, or through the context menu.

![ffxiv_dx11_fTtCC6lMqN](https://github.com/NightmareXIV/HuntTrainAssistant/assets/484335/0a99ae04-3de0-4515-bfb9-e54d39aadc0b)