### PR TITLE
exclude "The Macarenses Angle" from auto teleport

### DIFF
--- a/HuntTrainAssistant/MapManager.cs
+++ b/HuntTrainAssistant/MapManager.cs
@@ -76,6 +76,10 @@ internal static class MapManager
                     // one spawn point is closer to it than Palaka accounting for height
                     Y -= 2f;
                     break;
+                case "The Macarenses Angle":
+                    // never worth teleporting to, not even for the spawn point that's right above, since upward movement is very slow
+                    Y += 999f;
+                    break;
             }
         }
         return new Vector2()


### PR DESCRIPTION
Amaurot is so far down that you should never go there, even if the target is right above

i couldn't test this since I can't get the project to compile (due to unresolved references to `ECommons.Funding` and `System.Windows.Forms`), but the change is so simple that it should work just fine