### PR TITLE
Printing "null" instead of trying to read zero pointer

### DIFF
--- a/HuntTrainAssistant/Services/LFGService.cs
+++ b/HuntTrainAssistant/Services/LFGService.cs
@@ -48,7 +48,7 @@ public unsafe class LFGService : IDisposable
             Param: {evt.EventParam}
             AtkEventType: {evt.AtkEventType}
             AtkEvent.Type: {atkEvent->State.EventType}
-            Data: {MemoryHelper.ReadRaw(evt.Data, 0x40).ToHexString()}
+            Data: {(evt.Data != nint.Zero ? MemoryHelper.ReadRaw(evt.Data, 0x40).ToHexString() : "null")}
             """);
     }
 


### PR DESCRIPTION
upon clicking create party finder button it raises an expection

```
20:51:42.384 | ERR | [AddonLifecycle] Exception in OnReceiveEvent during PostReceiveEvent invoke.
	System.NullReferenceException: Object reference not set to an instance of an object.
	   at HuntTrainAssistant.Services.LFGService.OnReceiveEvent(AddonEvent type, AddonArgs args) in D:\VS\HuntTrainAssistant\HuntTrainAssistant\Services\LFGService.cs:line 47
	   at Dalamud.Game.Addon.Lifecycle.AddonLifecycle.InvokeListenersSafely(AddonEvent eventType, AddonArgs args, String blame) in /_/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs:line 170
```

if I check is evt.Data is null

```Data: {(evt.Data != nint.Zero ? MemoryHelper.ReadRaw(evt.Data, 0x40).ToHexString() : "null")}```

it is indeed null

```20:53:08.734 | INF | [HuntTrainAssistant] Param: 26
	AtkEventType: 25
	AtkEvent.Type: ButtonClick
	Data: null
```

so i guess that's a necessary fix? i am not very experienced in plugin developpement, not sure if it's normal that data is null